### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,7 @@
     "url": "https://github.com/shinnn/parse-author-name.js/issues"
   },
   "homepage": "https://github.com/shinnn/parse-author-name.js",
-  "license": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/shinnn/parse-author-name.js/blob/master/LICENSES.md"
-    }
-  ],
+  "license": "MIT",
   "keywords": [
     "string",
     "contact",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
